### PR TITLE
Use reset_index(): give index a column name instead of adding new col

### DIFF
--- a/scripts/catalog_notebook.py
+++ b/scripts/catalog_notebook.py
@@ -9,7 +9,7 @@
 #     "pyarrow==20.0.0",
 #     "pyodide-http==0.2.2",
 #     "requests==2.32.4",
-#     "sxscatalog==3.0.16",
+#     "sxscatalog==3.0.17",
 #     "traitlets==5.14.3",
 # ]
 # ///

--- a/scripts/catalog_notebook.py
+++ b/scripts/catalog_notebook.py
@@ -192,7 +192,7 @@ def _(deprecation, df0, eccentricity, precession, system_type):
     columns = preferred_columns + [c for c in df.columns if c not in preferred_columns]
     df = df[columns]
 
-    df["SXS ID"] = list(df.index)
+    df.reset_index(names="SXS ID", inplace=True)
     return df, preferred_columns
 
 
@@ -345,16 +345,16 @@ def _(chart_data, math, mo, tag_name):
     load_code = (
         f"""import sxs\ndf = sxs.load("dataframe", tag="{tag_name}")\n"""
         + (
-            f"""sim = sxs.load("{chart_data.index[0]}")"""
+            f"""sim = sxs.load("{chart_data["SXS ID"][0]}")"""
             if len(chart_data)==1 else
             (
-                "sims = [sxs.load(sxs_id) for sxs_id in [\"" + "\", \"".join(chart_data.index) + "\"]]"
+                "sims = [sxs.load(sxs_id) for sxs_id in [\"" + "\", \"".join(chart_data["SXS ID"]) + "\"]]"
                 if len(chart_data) < max_width else
                 (
                     "sims = [sxs.load(sxs_id) for sxs_id in [\n    \""
                     + "\",\n    \"".join(
-                        "\", \"".join(chart_data.index[i:min(i+max_width, len(chart_data.index))])
-                        for i in range(0, math.ceil(len(chart_data.index)/max_width)*max_width, max_width)
+                        "\", \"".join(chart_data["SXS ID"][i:min(i+max_width, len(chart_data["SXS ID"]))])
+                        for i in range(0, math.ceil(len(chart_data["SXS ID"])/max_width)*max_width, max_width)
                     )
                     + "\"\n]]"
                 )

--- a/src/sxscatalog/__about__.py
+++ b/src/sxscatalog/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Mike Boyle <michael.oliver.boyle@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "3.0.16"
+__version__ = "3.0.17"


### PR DESCRIPTION
This avoids the appearance of "null" in the index column when filtering the table of simulations.

CI failure is because the publish action only has deploy keys on upstream — separate issue, we should add a check and only run deploy from upstream.