### PR TITLE
Two more string_converters, for normalizing keywords and EOS fields

### DIFF
--- a/src/sxscatalog/simulations/simulations.py
+++ b/src/sxscatalog/simulations/simulations.py
@@ -547,6 +547,8 @@ class Simulations(collections.OrderedDict):
                 three_vec: np.array([np.nan, np.nan, np.nan]),
                 norm: np.nan,
                 datetime_from_string: pd.NaT,
+                ensure_list: [],
+                str_join_or_None: None,
             }
             try:
                 default_value = default_values[mapper]
@@ -593,7 +595,7 @@ class Simulations(collections.OrderedDict):
             three_vector_dataframe(simulations, "remnant_dimensionless_spin"),
             three_vector_dataframe(simulations, "remnant_velocity"),
             # get(simulations, "final_time", floater),
-            get(simulations, "EOS", np.nan).fillna(get(simulations, "eos", np.nan)),
+            get(simulations, "EOS", str_join_or_None).fillna(get(simulations, "eos", str_join_or_None)),
             get(simulations, "disk_mass", floater),
             get(simulations, "ejecta_mass", floater),
             get(simulations, "object_types", "").astype("category"),
@@ -623,7 +625,7 @@ class Simulations(collections.OrderedDict):
             get(simulations, "number_of_orbits_from_start", floater),
             get(simulations, "number_of_orbits_from_reference_time", floater),
             get(simulations, "DOI_versions", []),
-            get(simulations, "keywords", []),
+            get(simulations, "keywords", ensure_list),
             get(simulations, "date_link_earliest", datetime_from_string),
             get(simulations, "date_run_earliest", datetime_from_string),
             get(simulations, "date_run_latest", datetime_from_string),

--- a/src/sxscatalog/utilities/string_converters.py
+++ b/src/sxscatalog/utilities/string_converters.py
@@ -48,3 +48,17 @@ def datetime_from_string(x):
     except:
         pass  # No timezone information present; assuming UTC
     return dt.tz_localize(None)
+
+def ensure_list(x):
+    """Make sure that this field is a list, rather than (say) a single string."""
+
+    return x if isinstance(x, list) else [x]
+
+def str_join_or_None(x):
+    """Join an array of strings into a string; or failing that, None"""
+
+    try:
+        s = "".join(x)
+    except:
+        s = None
+    return s


### PR DESCRIPTION
Some simulations have keywords being a single string ("deprecated") instead of a list of strings. The string_converter ensure_list noramlizes the column to always be a list of strings.

Some NSNS simulations' EOS fields were incorrectly parsed (in the txt->json conversion) into a list of strings, rather than a single string. The string_converter str_join_or_None tries to join a list of strings into a list, or failing that, returns None.