### PR TITLE
number_of_orbits was erroneously dropped when slurping RIT catalog

### DIFF
--- a/src/sxscatalog/utilities/convert_other_catalogs/convert_RIT_site.py
+++ b/src/sxscatalog/utilities/convert_other_catalogs/convert_RIT_site.py
@@ -96,7 +96,6 @@ def fetch_RIT_catalog_data():
             # _backwards_compatibility() adds number_of_orbits=NaN, which we
             # don't want. Throw away both of these keys.
             RITcatalogdata[sim_id].pop("metadata_path", None)
-            RITcatalogdata[sim_id].pop("number_of_orbits", None)
 
         RITcatalogdata[sim_id]["extrap_psi4_url"] = RITcatalog_url + psi_link["href"]
         RITcatalogdata[sim_id]["extrap_strain_url"] = (


### PR DESCRIPTION
This was a silly oversight... some of the RIT metadata was missing number_of_orbits, and we only spot-checked and thought the NaNs we were getting were "wrong". But most RIT metadata _does_ have number_of_orbits.