### PR TITLE
Avoid load to check attribute simulations

### DIFF
--- a/src/sxscatalog/simulations/rit_maya_simulations.py
+++ b/src/sxscatalog/simulations/rit_maya_simulations.py
@@ -149,9 +149,6 @@ class RITSimulations(Simulations):
         sxs.sxs_directory : Locate cache directory Simulations.reload
 
         """
-        if hasattr(cls, "_simulations") and not ignore_cached:
-            return cls._simulations
-
         import json
         import zipfile
         import warnings
@@ -480,9 +477,6 @@ class MAYASimulations(Simulations):
         sxs.sxs_directory : Locate cache directory Simulations.reload
 
         """
-        if hasattr(cls, "_simulations") and not ignore_cached:
-            return cls._simulations
-
         import json
         import zipfile
         import warnings

--- a/src/sxscatalog/simulations/rit_maya_simulations.py
+++ b/src/sxscatalog/simulations/rit_maya_simulations.py
@@ -149,6 +149,9 @@ class RITSimulations(Simulations):
         sxs.sxs_directory : Locate cache directory Simulations.reload
 
         """
+        if "_simulations" in cls.__dict__ and not ignore_cached:
+            return cls._simulations
+
         import json
         import zipfile
         import warnings
@@ -477,6 +480,9 @@ class MAYASimulations(Simulations):
         sxs.sxs_directory : Locate cache directory Simulations.reload
 
         """
+        if "_simulations" in cls.__dict__ and not ignore_cached:
+            return cls._simulations
+
         import json
         import zipfile
         import warnings


### PR DESCRIPTION
Hi @moble and @duetosymmetry. These changes avoid setting the attribute `_simulations` to the parent class. Otherwise `RITSimulations._simulations` or `MAYASimulations._simulations` would still give the SXS `Simulations._simulations` object. If you think there is a better way, please let me know.